### PR TITLE
update cart_items controllers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,5 @@ gem 'kaminari'
 gem 'faker'
 
 gem 'redis_object'
+
+ gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -156,6 +157,11 @@ GEM
     nokogiri (1.10.0)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (3.1.0)
     public_suffix (3.0.3)
     puma (3.12.0)
@@ -288,6 +294,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   listen (>= 3.0.5, < 3.2)
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.2)
   redis_object

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -1,19 +1,49 @@
 class CartItemsController < ApplicationController
 	def add_item
+	#sessionにcartを保存するやり方
 		# session[:cart_id] = nil  ← 1回カートを作った後に "$ db:migrate:reset" をした場合に，コメントアウトして使ってください．
 									# migrate:resetしても，cart_idに限っては session に残ってしまう（session[:cart_id]を使って session に保存しているため．）ので，session[:cart_id]を1度nilにしてカートを消し，またコメントアウトして商品を追加すればエラーが消えます．．
-		if  session[:cart_id].nil?
-			@cart = Cart.new
-			@cart.user_id = current_user.id
-			@cart.save
-			session[:cart_id] = @cart.id
+		# if  session[:cart_id].nil?
+		# 	@cart = Cart.new
+		# 	@cart.user_id = current_user.id
+		# 	@cart.save
+		# 	session[:cart_id] = @cart.id
+		# else
+		# 	@cart = Cart.find(session[:cart_id])
+		# end
+	#sessionにcartを保存するやり方
+
+		if  Cart.all.last.added_at
+			cart = Cart.new(user_id: current_user.id)
+			cart.save
 		else
-			@cart = Cart.find(session[:cart_id])
+			cart = Cart.all.last
 		end
-		@cart_item = CartItem.new(cart_item_params)
-		@cart_item.cart_id = @cart.id
+
+		# 以下の1行は，28〜35行目と同義だが，if文を書かないと使えないらしい
+		# is_find = current_user.carts.last.cart_items.find_by(product_id: params[:cart_item][:product_id]).product_id
+
+		@cart_items = current_user.carts.last.cart_items
+		is_find = 0
+		@cart_items.each do |cart_item|
+			product = cart_item.product
+			if params[:cart_item][:product_id].to_i == product.id
+				is_find = cart_item.id
+			else
+				is_find = 0
+			end
+		end
+
+		if is_find == 0
+			@cart_item = CartItem.new(cart_item_params)
+			@cart_item.cart_id = cart.id
+		else
+			@cart_item = CartItem.find(is_find)
+			@cart_item.quantity += params[:cart_item][:quantity].to_i
+		end
+
 		if @cart_item.save
-			redirect_to cart_path(@cart), flash: {key: "#{@cart_item.product.name}をカートに追加しました．"}
+			redirect_to cart_path(cart), flash: {key: "#{@cart_item.product.name}をカートに追加しました．"}
 		else
 			#render先のアクションが持っているインスタンス変数を持っていく．持っていきたい値「product_id」は「cart_item」の中にあるので，2つ続けて書く．
 			@product = Product.find(params[:cart_item][:product_id])

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,3 +1,4 @@
 class Cart < ApplicationRecord
-	has_many :cart_items
+	has_many :cart_items, dependent: :destroy
+	belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
     has_many :addresses
     has_many :orders
+    has_many :carts
 
     attachment :profile_image
     

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -45,18 +45,23 @@
 			<!-- 商品へのコメント -->
 		</div>
 		<div class="col-xs-4">
-			<div class="show-sidebar">ユーザーなら「カートに入れるボタン」（アーティストなら「商品編集ボタン」），「数量変更増減矢印」，「小計」d
+			<div class="show-sidebar">ユーザーなら「カートに入れるボタン」「数量変更増減矢印」「小計」，アーティストなら「商品編集ボタン」
 				<% if @cart_item.errors %>
 					<% @cart_item.errors.full_messages.each do |e| %>
 						<%= e %>
 					<% end %>
 				<% end %>
+				<!-- 一般ユーザ用 -->
 		    	<%= form_for @cart_item do |f| %>
 		    		<%= f.hidden_field :product_id, value: @product.id %>
 		    		<%= f.hidden_field :price, value: @product.price %>
-		    		<%= f.number_field :quantity, value: @cart_item.quantity.to_i, min: 1 %>
-		    		<p><%= f.submit "Add to Cart", class: "btn btn-primary" %></p>
+		    		<p>数量: <%= f.number_field :quantity, value: @cart_item.quantity.to_i, min: 1, max: 99%></p>
+		    		<p><%= f.submit "カートに入れる ※ for user", class: "btn btn-primary" %></p>
 		    	<% end %>
+		    	<!-- 一般ユーザ用 -->
+		    	<!-- アーティスト用 -->
+		    	<%= link_to "商品情報編集　※ for artist", edit_product_path(@product), class: "btn btn-primary" %>
+		    	<!-- アーティスト用 -->
 		    </div>
 		</div>
 	</div>


### PR DESCRIPTION
カートに商品が入っている時に，カートに入っている商品と同じ商品をカートに追加したら数量が増えるように更新しました．

コメントアウトがたくさんあるため見難いと思いますが，勉強のために置いておきます．

（変更前）
・カートをセッションに保存していたため，データベースリセットをしてもセッションにデータが残る．
・カートに商品が入っている時，後から再び同じ商品を追加すると，カート内で商品がダブって表示される．

（変更後）
・カートをデータベースだけに保存し，データベースリセットで全て消える．
・カート内に商品が入っている時，後から再び同じ商品を追加すると，数量が増える．
（？）もしかすると，サインアップして初めてカートに商品を追加するとエラーが出るかも・・・



